### PR TITLE
Simplify terrain type descriptions in Space Ship scene

### DIFF
--- a/Assets/Scenes/Space Ship.unity
+++ b/Assets/Scenes/Space Ship.unity
@@ -8293,10 +8293,9 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Los terrenos karsticos son paisajes formados por la disolucion de rocas
-    solubles como la caliza, dolomita, yeso o sal, creando caracteristicas unicas
-    como dolinas (depresiones superficiales), cuevas, cenotes y sistemas de drenaje
-    subterraneo.
+  m_text: Este tipo de terreno aparece cuando ciertas rocas, como la caliza o el
+    yeso, se van disolviendo con el agua. Con el tiempo, el suelo forma cosas muy
+    interesantes como formas sorprendentes creadas por la naturaleza.
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: d97aea35a2c179444a64bae13eceb878, type: 2}
   m_sharedMaterial: {fileID: 8281081451498079583, guid: d97aea35a2c179444a64bae13eceb878, type: 2}
@@ -9299,9 +9298,9 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Un terreno poroso es aquel que tiene huecos o espacios interconectados
-    entre sus particulas solidas, lo que le permite absorber y permitir el paso de
-    liquidos y gases como el agua y el aire.
+  m_text: 'Piensa en una esponja: tiene muchos huequitos. Un terreno poroso es parecido,
+    porque tiene espacios entre sus partes, lo que permite que el agua y el aire
+    pasen y se muevan por dentro.'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: d97aea35a2c179444a64bae13eceb878, type: 2}
   m_sharedMaterial: {fileID: 8281081451498079583, guid: d97aea35a2c179444a64bae13eceb878, type: 2}
@@ -10387,8 +10386,9 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Un terreno fissural se refiere a una fractura lineal o grieta larga y
-    estrecha que se presenta en la superficie del suelo o la roca. '
+  m_text: "Imagina que el suelo tiene una l\xEDnea larga y delgada, como una grieta
+    hecha con un l\xE1piz. Eso es un terreno fissural: el suelo o la roca se abre
+    y queda una fractura larga y estrecha."
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: d97aea35a2c179444a64bae13eceb878, type: 2}
   m_sharedMaterial: {fileID: 8281081451498079583, guid: d97aea35a2c179444a64bae13eceb878, type: 2}


### PR DESCRIPTION
Updated the text descriptions for karstic, porous, and fissural terrains in the Space Ship scene to use simpler, more accessible language. This makes the information easier to understand for a broader audience.