### PR TITLE
Disable character controller center update each frame

### DIFF
--- a/Assets/Prefabs/XR Rig.prefab
+++ b/Assets/Prefabs/XR Rig.prefab
@@ -8990,7 +8990,7 @@ MonoBehaviour:
   m_UseLocalSpaceGravity: 1
   m_TerminalVelocity: 90
   m_GravityAccelerationModifier: 1
-  m_UpdateCharacterControllerCenterEachFrame: 1
+  m_UpdateCharacterControllerCenterEachFrame: 0
   m_SphereCastRadius: 0.09
   m_SphereCastDistanceBuffer: -0.05
   m_SphereCastLayerMask:


### PR DESCRIPTION
Set m_UpdateCharacterControllerCenterEachFrame to 0 in XR Rig prefab to prevent updating the character controller center every frame. This may improve performance or address issues related to character controller updates.