### PR TITLE
Prevent trigger when indicator is inactive

### DIFF
--- a/Assets/Script/SquirrelTrigger.cs
+++ b/Assets/Script/SquirrelTrigger.cs
@@ -68,7 +68,7 @@ public class SquirrelTrigger : MonoBehaviour
 
     private void OnTriggerEnter(Collider other)
     {
-        if (hasTriggered)
+        if (hasTriggered || !isIndicatorActive)
         {
             return;
         }


### PR DESCRIPTION
Updated OnTriggerEnter to return early if the indicator is not active, in addition to the existing hasTriggered check. This prevents the trigger logic from executing when the indicator is not active.