### PR TITLE
Fix explanation display on max mistakes

### DIFF
--- a/Assets/Script/TriviaController.cs
+++ b/Assets/Script/TriviaController.cs
@@ -196,7 +196,7 @@ public class TriviaController : MonoBehaviour
 
                 if (mistakeCount >= MAX_MISTAKES)
                 {
-                    ShowText("q[i].explanation");
+                    ShowText(q[i].explanation);
                     yield return new WaitUntil(() => !isTyping);
 
                     HideText();


### PR DESCRIPTION
Replaces string literal with actual explanation property when showing text after reaching maximum mistakes.